### PR TITLE
Hot fix for directory creation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>me.github.simonplays15.betterbansystem</groupId>
     <artifactId>BetterBanSystem</artifactId>
-    <version>1.0</version>
+    <version>1.0.1</version>
     <developers>
         <developer>
             <name>SimonPlays15</name>

--- a/src/main/java/me/github/simonplays15/betterbansystem/core/BetterBanSystem.java
+++ b/src/main/java/me/github/simonplays15/betterbansystem/core/BetterBanSystem.java
@@ -35,6 +35,8 @@ import org.jetbrains.annotations.Nullable;
 import java.io.File;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 public abstract class BetterBanSystem {
 
@@ -265,6 +267,14 @@ public abstract class BetterBanSystem {
         new BanManager().start();
         new MuteManager().start();
         new WarnManager().start();
+
+        new Updater().getVersion(version -> {
+            if (!this.getPluginDescription().getVersion().equals(version))
+                CompletableFuture.delayedExecutor(4, TimeUnit.SECONDS).execute(() -> {
+                    GlobalLogger.getLogger().info("A new update is available for BetterBanSystem: v" + version);
+                });
+        });
+
     }
 
     /**

--- a/src/main/java/me/github/simonplays15/betterbansystem/core/BetterBanSystem.java
+++ b/src/main/java/me/github/simonplays15/betterbansystem/core/BetterBanSystem.java
@@ -214,6 +214,8 @@ public abstract class BetterBanSystem {
     public BetterBanSystem(File dataFolder) throws RuntimeException {
         instance = this;
         this.dataFolder = dataFolder;
+        if (!this.dataFolder.exists())
+            this.dataFolder.mkdirs();
         UUIDFetcher.loadUsercacheJson();
         ResourceFile resourceFile = new ResourceFile(this.dataFolder);
 

--- a/src/main/java/me/github/simonplays15/betterbansystem/core/Updater.java
+++ b/src/main/java/me/github/simonplays15/betterbansystem/core/Updater.java
@@ -1,0 +1,36 @@
+package me.github.simonplays15.betterbansystem.core;/*
+ * Copyright (c) SimonPlays15 2024. All Rights Reserved
+ */
+
+/*
+ * Copyright (c) SimonPlays15 2024. All Rights Reserved
+ */
+
+import me.github.simonplays15.betterbansystem.core.logging.GlobalLogger;
+
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Scanner;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+public class Updater {
+
+    private final int resourceId;
+
+    public Updater() {
+        this.resourceId = 114538;
+    }
+
+    public void getVersion(final Consumer<String> version) {
+        CompletableFuture.runAsync(() -> {
+            try (InputStream in = new URL("https://api.spigotmc.org/legacy/update.php?resource=" + this.resourceId + "/~").openStream(); Scanner scann = new Scanner(in)) {
+                if (scann.hasNext())
+                    version.accept(scann.next());
+            } catch (Exception ex) {
+                GlobalLogger.getLogger().error("Unable to check for updates", ex);
+            }
+        });
+    }
+
+}

--- a/src/main/java/me/github/simonplays15/betterbansystem/core/logging/GlobalLogger.java
+++ b/src/main/java/me/github/simonplays15/betterbansystem/core/logging/GlobalLogger.java
@@ -184,6 +184,8 @@ public class GlobalLogger extends Logger {
      * @see FileHandler#FileHandler(String, boolean)
      */
     private void configureFileHandler() throws IOException {
+        if (!this.writeLogsToFile)
+            return;
         if (new Date().equals(this.currentDate)) {
             return;
         } else {
@@ -317,7 +319,7 @@ public class GlobalLogger extends Logger {
         try {
             configureFileHandler();
         } catch (IOException e) {
-            System.err.println("[BetterBanSystem] " + e.getCause().getClass().getName() + ": " + e.getMessage());
+            System.err.println("[BetterBanSystem] Failed to create the FileHandler\n" + e);
         }
     }
 


### PR DESCRIPTION
#1 NullPointerException after enabling the plugin on a PaperSpigot Minecraft Server.
Ensure that on the "onEnable" Method that every directory is created before creating the given files.
Fixed a Bug inside the GlobalLogger which throws a NullPointerException because the thrown IOException is giving no cause.